### PR TITLE
ensure realm is bytestring

### DIFF
--- a/python_digest/__init__.py
+++ b/python_digest/__init__.py
@@ -45,6 +45,8 @@ def calculate_partial_digest(username, realm, password):
     Calculate a partial digest that may be stored and used to authenticate future
     HTTP Digest sessions.
     '''
+    if isinstance(realm, six.text_type):
+        realm = realm.encode('utf-8')
     return md5.md5(b"%s:%s:%s" % (username.encode('utf-8'), realm, password.encode('utf-8'))).hexdigest()
 
 def build_digest_challenge(timestamp, secret, realm, opaque, stale):


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/503922499/

Prevents errors when username or password contains international characters.

@dimagi/py3 